### PR TITLE
Fix website from x-overflowing on small viewports

### DIFF
--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -15,7 +15,7 @@
         </section>
 
 
-        <section class="main-content columns">
+        <section class="main-content columns is-marginless">
             <div class="container column is-10">
                 <Nuxt />
             </div>


### PR DESCRIPTION
Just a small improvement. But the website was overflowing on the left and right on small viewports. It seems like adding the ```is-marginless``` class fixes the issue. 