### PR TITLE
Add status URL for Escape from Tarkov

### DIFF
--- a/src/static/games.json
+++ b/src/static/games.json
@@ -243,7 +243,7 @@
   },
   {
     "game": "Escape from Tarkov",
-    "acStatusUrl": "",
+    "acStatusUrl": "https://forum.escapefromtarkov.com/topic/157618-linuxmac-proton-support/",
     "acStatus": "❔ Unconfirmed",
     "acName": "BattlEye",
     "acList": [


### PR DESCRIPTION
(still unconfirmed as there's no official statement)