### PR TITLE
Fix Sabreclaw→Sabreclaw for Hired Ops

### DIFF
--- a/src/static/games.json
+++ b/src/static/games.json
@@ -1927,7 +1927,7 @@
     "gameUrl": "https://www.hiredops.com/",
     "acName": "",
     "acList": [
-      "Saberclaw"
+      "Sabreclaw"
     ]
   },
   {


### PR DESCRIPTION
Change Sabreclaw→Sabreclaw, actual name for Hired Ops anticheat.