### PR TITLE
Change status URL to Ubisoft response on forums

### DIFF
--- a/src/static/games.json
+++ b/src/static/games.json
@@ -99,7 +99,7 @@
         "BattlEye"
     ],
     "acStatus": "❔ Unconfirmed",
-    "acStatusUrl": "https://www.theverge.com/2021/10/5/22709918/valve-steam-deck-supported-games-anti-cheat-proton-eac-battleye-epic"
+    "acStatusUrl": "https://discussions.ubisoft.com/topic/121755/proton-support-for-r6-siege-would-be-awesome/2?lang=en-US"
   },
   {
     "game": "SMITE",

--- a/src/static/games.json
+++ b/src/static/games.json
@@ -99,7 +99,7 @@
         "BattlEye"
     ],
     "acStatus": "❔ Unconfirmed",
-    "acStatusUrl": "https://discussions.ubisoft.com/topic/121755/proton-support-for-r6-siege-would-be-awesome/2?lang=en-US"
+    "acStatusUrl": "https://discussions.ubisoft.com/topic/121755/proton-support-for-r6-siege-would-be-awesome/2"
   },
   {
     "game": "SMITE",


### PR DESCRIPTION
The prior verge article mentioned "We don’t have anything to share at
this time", this is now an official response to deliver feedback to the
dev team.

The state hasn't changed but perhaps it would be more useful to link to
a place for people to post: +1's