### PR TITLE
Steam announced official support for DayZ, PlanetSide 2, Arma 3 

### DIFF
--- a/bin/games.txt
+++ b/bin/games.txt
@@ -12,7 +12,7 @@ SMITE~Easy Anti-Cheat~❔ Unconfirmed
 Black Desert Online~Easy Anti-Cheat~❔ Unconfirmed
 Fall Guys: Ultimate Knockout~Easy Anti-Cheat~❔ Unconfirmed
 ARK: Survival Evolved~BattlEye~⭐ Supported
-DayZ~BattlEye~❔ Unconfirmed
+DayZ~BattlEye~⭐ Supported
 Dead By Daylight~Easy Anti-Cheat~🎉 Confirmed
 Destiny 2~BattlEye~❔ Unconfirmed
 Hunt: Showdown~Easy Anti-Cheat~❔ Unconfirmed
@@ -24,12 +24,12 @@ New World~Easy Anti-Cheat~❔ Unconfirmed
 Warhammer: Vermintide 2~Easy Anti-Cheat~❔ Unconfirmed
 Escape from Tarkov~BattlEye~❔ Unconfirmed
 Insurgency: Sandstorm~Easy Anti-Cheat~❔ Unconfirmed
-ArmA 3~BattlEye~🎉 Confirmed
+ArmA 3~BattlEye~⭐ Supported
 Rogue Company~Easy Anti-Cheat~❔ Unconfirmed
 Realm Royale~Easy Anti-Cheat~❔ Unconfirmed
 Phantasy Star Online 2~nProtect GameGuard~❔ Unconfirmed
 Unturned~BattlEye~⭐ Supported
-PlanetSide 2~BattlEye~❔ Unconfirmed
+PlanetSide 2~BattlEye~⭐ Supported
 For Honor~Easy Anti-Cheat~❔ Unconfirmed
 NARAKA: BLADEPOINT~NEAC Protect~❔ Unconfirmed
 Genshin Impact~miHoYo Protect 2~❔ Unconfirmed

--- a/src/static/games.json
+++ b/src/static/games.json
@@ -148,8 +148,8 @@
     "acList": [
         "BattlEye"
     ],
-    "acStatus": "❔ Unconfirmed",
-    "acStatusUrl": "https://www.theverge.com/2021/10/5/22709918/valve-steam-deck-supported-games-anti-cheat-proton-eac-battleye-epic"
+    "acStatus": "⭐ Supported",
+    "acStatusUrl": "https://store.steampowered.com/news/group/4145017/view/3104663180636096966"
   },
   {
     "game": "Dead By Daylight",
@@ -263,8 +263,8 @@
   },
   {
     "game": "ArmA 3",
-    "acStatusUrl": "https://github.com/Starz0r/AreWeAntiCheatYet/issues/103#issuecomment-939699485",
-    "acStatus": "🎉 Confirmed",
+    "acStatusUrl": "https://store.steampowered.com/news/group/4145017/view/3104663180636096966",
+    "acStatus": "⭐ Supported",
     "acName": "BattlEye",
     "acList": [
         "BattlEye"
@@ -314,8 +314,8 @@
   },
   {
     "game": "PlanetSide 2",
-    "acStatusUrl": "",
-    "acStatus": "❔ Unconfirmed",
+    "acStatusUrl": "https://store.steampowered.com/news/group/4145017/view/3104663180636096966",
+    "acStatus": "⭐ Supported",
     "acName": "BattlEye",
     "acList": [
         "BattlEye"


### PR DESCRIPTION
### Game Titles
DayZ, PlanetSide 2, Arma 3

### Due To
https://store.steampowered.com/news/group/4145017/view/3104663180636096966

### This closes
https://github.com/Starz0r/AreWeAntiCheatYet/issues/270
https://github.com/Starz0r/AreWeAntiCheatYet/issues/271
https://github.com/Starz0r/AreWeAntiCheatYet/issues/272
