### PR TITLE
Add table to display individual game totals for each type of anti-cheat

### DIFF
--- a/src/components/OverView.vue
+++ b/src/components/OverView.vue
@@ -6,6 +6,7 @@
                 <p class="pill isConfirmed">🎉 Confirmed {{noConfirmed}}</p>
                 <p class="pill isUnconfirmed">❔ Unconfirmed: {{noUnconfirmed}}</p>
                 <p class="pill isTotal">📈 Total: {{total}}</p>
+                <p v-on:click="breakdownVisible = !breakdownVisible" class="pill breakdown" v-text="breakdownVisible ? '⬆️ Hide Breakdown' : '⬇️ Show Breakdown'"></p>
         </div>
 
         <div class="row is-mobile is-centered">
@@ -20,14 +21,14 @@
             </b-progress>
             </div>
 
-        <table class="row is-mobile is-centered" >
-        <tr v-for="(item,key) in gametotal" :key="key" class="pill" >
-        <td><img v-if="item.logo" :src="item.logo" width="32" height="32" />{{key}}({{item.no}})</td>
-        <td class=""  style="width:80%;vertical-align:middle;"><b-progress :max="item.no" size="is-large" >
+        <table v-show="breakdownVisible" class="row is-mobile is-centered" >
+        <tr v-for="(item,key) in gametotal"  :key="key" class="pill" >
+        <td v-if="item.no>0"><img v-if="item.logo" :src="item.logo" width="32" height="32" />{{key}}({{item.no}})</td>
+        <td v-if="item.no>0" class="breakdownPill"><b-progress :max="item.no" size="is-large" >
         <template #bar>
-            <b-progress-bar :value="item.Supported" type="is-success" show-value></b-progress-bar>
-            <b-progress-bar :value="item.Confirmed" type="is-info" show-value></b-progress-bar>
-            <b-progress-bar :value="item.Unconfirmed"  show-value></b-progress-bar>
+            <b-progress-bar v-if="item.Supported>0" :value="item.Supported" type="is-success" show-value></b-progress-bar>
+            <b-progress-bar v-if="item.Confirmed>0" :value="item.Confirmed" type="is-info" show-value></b-progress-bar>
+            <b-progress-bar v-if="item.Unconfirmed>0" :value="item.Unconfirmed"  show-value></b-progress-bar>
         </template>
         </b-progress>
          </td>
@@ -81,6 +82,7 @@ export default {
             supportedPercent:this.noSupported/total*100,
             unconfirmedPercent:this.noUnconfirmed/total*100,
             gametotal,
+            breakdownVisible:false,
             };
     }
 }
@@ -114,6 +116,20 @@ export default {
 
     .isTotal{
         background: rgb(255, 174, 0);
+    }
+
+    .breakdown{
+        padding: 0.2rem 1rem 0.2rem 1rem;
+        border: 0.12rem solid black;
+    }
+    .breakdown:hover{
+        background: #167df0;
+        color: white;
+    }
+
+    .breakdownPill{
+        width:80%;
+        vertical-align:middle;
     }
 
     .row{

--- a/src/components/OverView.vue
+++ b/src/components/OverView.vue
@@ -20,6 +20,19 @@
             </b-progress>
             </div>
 
+        <table class="row is-mobile is-centered" >
+        <tr v-for="(item,key) in gametotal" :key="key" class="pill" >
+        <td><img v-if="item.logo" :src="item.logo" width="32" height="32" />{{key}}({{item.no}})</td>
+        <td class=""  style="width:80%;vertical-align:middle;"><b-progress :max="item.no" size="is-large" >
+        <template #bar>
+            <b-progress-bar :value="item.Supported" type="is-success" show-value></b-progress-bar>
+            <b-progress-bar :value="item.Confirmed" type="is-info" show-value></b-progress-bar>
+            <b-progress-bar :value="item.Unconfirmed"  show-value></b-progress-bar>
+        </template>
+        </b-progress>
+         </td>
+        </tr>
+        </table>
         </div>
     </div>
 </template>
@@ -40,17 +53,34 @@ export default {
     noConfirmed:{
         type:Number,
         default:0
-    }
+    },
+    gamecount:{
+        type:Object,
+        default(){}
+    },
   },
   
     data(){
         const total=this.noUnconfirmed+this.noSupported+this.noConfirmed;
         
+        const gametotal = {};
+        for (const key in this.gamecount){
+            const sum = this.gamecount[key]['❔ Unconfirmed']+this.gamecount[key]['⭐ Supported']+this.gamecount[key]['🎉 Confirmed'];
+            gametotal[key] = {
+            logo:this.gamecount[key].logo,
+            no:sum,
+            Unconfirmed:this.gamecount[key]['❔ Unconfirmed'],
+            Supported:this.gamecount[key]['⭐ Supported'],
+            Confirmed:this.gamecount[key]['🎉 Confirmed']
+            };
+        }
+
         return {
             total,
             conmfirmedPercent:this.noConfirmed/total*100,
             supportedPercent:this.noSupported/total*100,
             unconfirmedPercent:this.noUnconfirmed/total*100,
+            gametotal,
             };
     }
 }

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -4,7 +4,9 @@
         <OverView
             :noUnconfirmed="noUnconfirmed"
             :noSupported="noSupported"
-            :noConfirmed="noConfirmed"/>
+            :noConfirmed="noConfirmed"
+            :gamecount="gamecount"
+            />
 
         <div class="columns is-mobile is-centered">
             <b-table :data="table" :columns="formatting" :row-class="(row, index) => color(row, index)"></b-table>
@@ -45,6 +47,20 @@ export default {
     data() {
         let noUnconfirmed,noSupported,noConfirmed;
         noUnconfirmed=noSupported=noConfirmed=0;
+        const gamecount = {
+            BattlEye:{logo:beLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            'Easy Anti-Cheat':{logo:eacLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            Vanguard:{logo:vanguardLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            'nProtect GameGuard':{logo:npggLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            XIGNCODE3:{logo:xc3Logo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            EQU8:{logo:equ8Logo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            VAC:{logo:vacLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            FairFight:{logo:ffLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            PunkBuster:{logo:pbLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            'Treyarch Anti-Cheat':{logo:tacLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            Arbiter:{logo:arbiterLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            Other:{'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+        }
 
         for (let i = 0; i < gamesList.length; i++) {
             const game = gamesList[i];
@@ -60,50 +76,62 @@ export default {
                 switch (game.acList[j]) {
                     case "BattlEye":
                         game.acLabel += `<p><img src="` + beLogo + `" width="32" height="32" alt/> BattlEye</p>`;
+                        gamecount.BattlEye[game.acStatus]++;
                     break;
 
                     case "Easy Anti-Cheat":
                         game.acLabel += `<p><img src="` + eacLogo + `" width="32" height="32" alt/> Easy Anti-Cheat</p>`;
+                        gamecount['Easy Anti-Cheat'][game.acStatus]++;
                     break;
 
                     case "Vanguard":
                         game.acLabel += `<p><img src="` + vanguardLogo + `" width="32" height="32" alt> Vanguard</p>`;
+                        gamecount.Vanguard[game.acStatus]++;
                     break;
 
                     case "nProtect GameGuard":
                         game.acLabel += `<p><img src="` + npggLogo + `" width="32" height="32" alt/> nProtect GameGuard</p>`;
+                        gamecount['nProtect GameGuard'][game.acStatus]++;
                     break;
 
                     case "XIGNCODE3":
                         game.acLabel += `<p><img src="` + xc3Logo + `" width="32" height="32" alt/> XIGNCODE3</p>`;
+                        gamecount.XIGNCODE3[game.acStatus]++;
                     break;
 
                     case "EQU8":
                         game.acLabel += `<p><img src="` + equ8Logo + `" width="32" height="32" alt/> EQU8</p>`;
+                        gamecount.EQU8[game.acStatus]++;
                     break;
 
                     case "VAC":
                         game.acLabel += `<p><img src="` + vacLogo + `" width="32" height="32" alt/> VAC</p>`;
+                        gamecount.VAC[game.acStatus]++;
                     break;
 
                     case "FairFight":
                         game.acLabel += `<p><img src="` + ffLogo + `" width="32" height="32" alt/> FairFight</p>`;
+                        gamecount.FairFight[game.acStatus]++;
                     break;
 
                     case "PunkBuster":
                         game.acLabel += `<p><img src="` + pbLogo + `" width="32" height="32" alt/> PunkBuster</p>`;
+                        gamecount.PunkBuster[game.acStatus]++;
                     break;
 					
                     case "Treyarch Anti-Cheat":
                         game.acLabel += `<p><img src="` + tacLogo + `" width="32" height="32" alt/> Treyarch Anti-Cheat</p>`;
+                        gamecount['Treyarch Anti-Cheat'][game.acStatus]++;
                     break;
 					
                     case "Arbiter":
                         game.acLabel += `<p><img src="` + arbiterLogo + `" width="32" height="32" alt/> Arbiter</p>`;
+                        gamecount.Arbiter[game.acStatus]++;
                     break;
 
                     default:
                         game.acLabel += `<p>` + game.acList[j] + `</p>`;
+                        gamecount.Other[game.acStatus]++;
                     break;
                 }
             }
@@ -145,6 +173,7 @@ export default {
             noUnconfirmed,
             noSupported,
             noConfirmed,
+            gamecount,
             formatting: [{field: 'game', label: 'Game', numeric: false, sortable: true, customSort: customSort('gameSortvalue'), searchable: true}, {field: 'acLabel', label: 'Anti-Cheat'}, {field: 'acStatus', label: 'Status', sortable: true, customSort: customSort('statusSortvalue')}]
         }
     },

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -59,6 +59,12 @@ export default {
             PunkBuster:{logo:pbLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
             'Treyarch Anti-Cheat':{logo:tacLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
             Arbiter:{logo:arbiterLogo,'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            'NEAC Protect':{'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            'miHoYo Protect 2':{'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            RICOCHET:{'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            'Nexon Game Security':{'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            Sabreclaw:{'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
+            Internal:{'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
             Other:{'❔ Unconfirmed':0,'⭐ Supported':0,'🎉 Confirmed':0},
         }
 
@@ -127,6 +133,36 @@ export default {
                     case "Arbiter":
                         game.acLabel += `<p><img src="` + arbiterLogo + `" width="32" height="32" alt/> Arbiter</p>`;
                         gamecount.Arbiter[game.acStatus]++;
+                    break;
+
+                    case "NEAC Protect":
+                        game.acLabel += `<p>NEAC Protect</p>`;
+                        gamecount['NEAC Protect'][game.acStatus]++;
+                    break;
+
+                    case "miHoYo Protect 2":
+                        game.acLabel += `<p>miHoYo Protect 2</p>`;
+                        gamecount['miHoYo Protect 2'][game.acStatus]++;
+                    break;
+
+                    case "RICOCHET":
+                        game.acLabel += `<p>RICOCHET</p>`;
+                        gamecount.RICOCHET[game.acStatus]++;
+                    break;
+
+                    case "Nexon Game Security":
+                        game.acLabel += `<p>Nexon Game Security</p>`;
+                        gamecount['Nexon Game Security'][game.acStatus]++;
+                    break;
+
+                    case "Sabreclaw":
+                        game.acLabel += `<p>Sabreclaw</p>`;
+                        gamecount.Sabreclaw[game.acStatus]++;
+                    break;
+
+                    case "❔ Internal":
+                        game.acLabel += `<p>Internal</p>`;
+                        gamecount.Internal[game.acStatus]++;
                     break;
 
                     default:


### PR DESCRIPTION
The current top bar gives a general idea of the progress, but it isn't clear that anti-cheat like VAC, FairFight and PunkBuster are almost completely supported compared to the rest without looking through a long list.

It's close enough to be functional but the styling is not completely correct as I had to revert to a HTML table because I couldn't get the vue table to align correctly.