### PR TITLE
Swap order of 'unconfirmed' and 'denied' lists

### DIFF
--- a/src/components/OverView.vue
+++ b/src/components/OverView.vue
@@ -4,8 +4,8 @@
         <div class="pillRow row is-mobile is-centered">
                 <p class="pill isSupported" >⭐ Supported: {{noSupported}}</p>
                 <p class="pill isConfirmed">🎉 Confirmed: {{noConfirmed}}</p>
-                <p class="pill isUnconfirmed">❔ Unconfirmed: {{noUnconfirmed}}</p>
                 <p class="pill isDenied">🚫 Denied: {{noDenied}}</p>
+                <p class="pill isUnconfirmed">❔ Unconfirmed: {{noUnconfirmed}}</p>
                 <p class="pill isTotal">📈 Total: {{total}}</p>
                 <button class="pill breakdownBtn" @click="breakdownVisible = !breakdownVisible" v-text="breakdownVisible ? '⬆️ Hide Breakdown' : '⬇️ Show Breakdown'"></button>
         </div>
@@ -17,8 +17,8 @@
             <template #bar>
                 <b-progress-bar :value="supportedPercent"    type="is-success" show-value></b-progress-bar>
                 <b-progress-bar :value="conmfirmedPercent"   type="is-info" show-value></b-progress-bar>
+                <b-progress-bar :value="deniedPercent"       type="is-danger" show-value></b-progress-bar>
                 <b-progress-bar :value="unconfirmedPercent"  show-value></b-progress-bar>
-				<b-progress-bar :value="deniedPercent"       type="is-danger" show-value></b-progress-bar>
             </template>
             </b-progress>
             </div>
@@ -33,8 +33,8 @@
                 <template #bar>
                     <b-progress-bar v-if="item.Supported>0" :value="item.Supported" type="is-success" show-value></b-progress-bar>
                     <b-progress-bar v-if="item.Confirmed>0" :value="item.Confirmed" type="is-info" show-value></b-progress-bar>
+                    <b-progress-bar v-if="item.Denied>0" :value="item.Denied" type="is-danger" show-value></b-progress-bar>
                     <b-progress-bar v-if="item.Unconfirmed>0" :value="item.Unconfirmed"  show-value></b-progress-bar>
-		        	<b-progress-bar v-if="item.Denied>0" :value="item.Denied" type="is-danger" show-value></b-progress-bar>
                 </template>
                 </b-progress>
                 </td>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,7 +5,7 @@
             :noUnconfirmed="noUnconfirmed"
             :noSupported="noSupported"
             :noConfirmed="noConfirmed"
-			:noDenied="noDenied"
+            :noDenied="noDenied"
             :gamecount="gamecount"
             />
 
@@ -177,7 +177,7 @@ export default {
             switch(game.acStatus){
                 case "❔ Unconfirmed":
                     noUnconfirmed++;
-                    game.statusSortvalue = "3";
+                    game.statusSortvalue = "4";
                 break;
 
                 case "⭐ Supported":
@@ -192,7 +192,7 @@ export default {
 				
                 case "🚫 Denied":
                     noDenied++;
-                    game.statusSortvalue = "4";
+                    game.statusSortvalue = "3";
                 break;
             }
 


### PR DESCRIPTION
Instead of scrolling all the way down past the unconfirmed games, the least helpful category, to see which games are 'denied', this PR places the denied games to be made placed right above them and right before 'confirmed'.

I also made sure the order was reflected in the progress bars as well.