### PR TITLE
Add Genshin Impact notice

### DIFF
--- a/games.json
+++ b/games.json
@@ -442,7 +442,9 @@
         "anticheats": [
             "miHoYo Protect 2"
         ],
-        "notes": []
+        "notes": [
+            "Running Genshin Impact using the current available means violates the Terms of Service laid out by COGNOSPHERE PTE, Ltd."
+        ]
     },
     {
         "url": "https://www.djmaxrespect.com/",


### PR DESCRIPTION
The way to run Genshin is not only extremely gray-zone, it violates the ToS. As playing on Linux could very well get the developer to hard-ban a high-investment account, users should be warned in order for them to make that choice with the right information.