### PR TITLE
Clarify Tarkov situation

### DIFF
--- a/games.json
+++ b/games.json
@@ -614,10 +614,15 @@
         "anticheats": [
             "BattlEye"
         ],
-        "notes": [],
+        "notes": [
+            [
+                "Logging in to the game works with BattlEye runtime, including trading, hideout management and offline raids",
+                ""
+            ]
+        ],
         "updates": [
             {
-                "name": "Emailed Battleye",
+                "name": "Emailed BattlEye",
                 "date": "Apr 27, 2022, 6:10 PM GMT+2",
                 "reference": "https://discord.com/channels/891628783176650773/891637148007141387/958009681119428648"
             }


### PR DESCRIPTION
BattlEye runtime is needed for the game to even launch, then trading and hideout management and offline raids are available with it. Also fixed BattlEye spelling.