### PR TITLE
Add status update for Halo: MCC

### DIFF
--- a/games.json
+++ b/games.json
@@ -25,6 +25,11 @@
                 "name": "Updated Linux EAC Files",
                 "date": "Aug 31, 2022, 17:00:12 UTC",
                 "reference": "https://steamdb.info/patchnotes/9367265/"
+            },
+            {
+                "name": "Still actively working on it",
+                "date": "Dec 15, 2022, 4:15 PM GMT+1",
+                "reference": "https://www.theverge.com/23499215/valve-steam-deck-interview-late-2022"
             }
         ],
         "storeIds": {


### PR DESCRIPTION
This is the most recent update I'm aware of.

>  ### Valve is still pushing on anti-cheat
>
> [...]
> 
> But that doesn’t mean Valve isn’t making progress — Griffais and Yang say it’s still actively working on support for Halo: The Master Chief Collection and Fall Guys, as just two examples. It expects them to both eventually be playable on the Steam Deck — though it may need some last tweaks from Epic. That’s because Epic owns Easy Anti-Cheat, which The Master Chief Collection uses, and it also owns Mediatonic, the developer of Fall Guys.