### PR TITLE
update league of legends launcher link

### DIFF
--- a/games.json
+++ b/games.json
@@ -3923,7 +3923,7 @@
         "notes": [
             [
                 "Works OOTB with Lutris",
-                "https://lutris.net/games/garena/"
+                "https://lutris.net/games/league-of-legends/"
             ]
         ],
         "updates": [],


### PR DESCRIPTION
Solves https://github.com/Starz0r/AreWeAntiCheatYet/issues/1109

As stated in the issue Garena is no longer the go to (an never was for most regions) League of Legends launcher