### PR TITLE
Fixing a typo in attributes for ESEA: Counter-Strike: Global Offensive

### DIFF
--- a/games.json
+++ b/games.json
@@ -1653,7 +1653,7 @@
     },
     {
         "url": "https://esea.net",
-        "name": "EASA: Counter-Strike: Global Offensive",
+        "name": "ESEA: Counter-Strike: Global Offensive",
         "logo": "",
         "native": false,
         "status": "Denied",
@@ -1664,7 +1664,7 @@
         "notes": [],
         "updates": [],
         "storeIds": {},
-        "slug": "easa-counterstrike-global-offensive"
+        "slug": "esea-counterstrike-global-offensive"
     },
     {
         "url": "https://www.teamfortress.com/",


### PR DESCRIPTION
As the title says, there was a typo in attributes name and slug for ESEA: Counter-Strike: Global Offensive, where it was written "EASA: Counter-Strike: Global Offensive" and "easa-counterstrike-global-offensive", respectively.