### PR TITLE
Update Farlight 84 status to Denied

### DIFF
--- a/games.json
+++ b/games.json
@@ -5748,6 +5748,11 @@
         "name": "Game started apply 1 day account ban with explicit linux denied message",
         "date": "Aug 21, 2025, 4:00 AM GMT",
         "reference": "https://www.protondb.com/app/1928420/?device=any"
+      },
+      {
+        "name": "Developer divided linux into abnormal environments",
+        "date": "Sep 25, 2025, 4:00 AM GMT",
+        "reference": "https://www.youtube.com/watch?v=hdo8vCJU0gw&t=134s"
       }
 	],
     "storeIds": {


### PR DESCRIPTION
Game no longer uses EAC, the current anticheat client used for this game is unknown.

Multiple account ban reported for playing on linux on ProtonDB.