### PR TITLE
Adding epic namespace for some games (Wildgate, Hell let loose, Hell is others, predecessor, and more)

### DIFF
--- a/games.json
+++ b/games.json
@@ -315,7 +315,11 @@
       }
     ],
     "storeIds": {
-      "steam": "578080"
+      "steam": "578080",
+      "epic": {
+        "namespace": "9361c8c6d2f34b42b5f2f61093eedf48",
+        "slug": "pubg-59c1d9"
+      }
     },
     "slug": "pubg-battlegrounds",
     "dateChanged": "2024-01-19T04:40:56.000Z"


### PR DESCRIPTION
I noticed many games were listed here but didn't have the epic namespace info (that we use in Heroic Games Launcher to show a warning about game's anticheat).

This PR adds the ones I noticed are missing.

Some games cannot be bought from Epic anymore so I couldn't set a slug (like divine knockout, or wild card football)